### PR TITLE
Turn usage into a grid, because grids are cool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+builder.sh
+builder.ps1

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,6 +10,7 @@ gleam_stdlib = "~> 0.29"
 hug = "~> 0.1"
 gleam_community_ansi = "~> 1.1"
 gleam_json = "~> 0.5"
+gleam_javascript = "~> 0.4"
 
 [javascript]
 runtime = "deno"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,16 +3,18 @@
 
 packages = [
   { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
-  { name = "gleam_community_ansi", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib", "gleam_bitwise"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "6E4E0CF2B207C1A7FCD3C21AA43514D67BC7004F21F82045CDCCE6C727A14862" },
-  { name = "gleam_community_colour", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "D27CE357ECB343929A8CEC3FBA0B499943A47F0EE1F589EE16AFC2DC21C61E5B" },
+  { name = "gleam_community_ansi", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib", "gleam_community_colour"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "6E4E0CF2B207C1A7FCD3C21AA43514D67BC7004F21F82045CDCCE6C727A14862" },
+  { name = "gleam_community_colour", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_bitwise"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "D27CE357ECB343929A8CEC3FBA0B499943A47F0EE1F589EE16AFC2DC21C61E5B" },
+  { name = "gleam_javascript", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "E0E8D33461776BFCC124838183F85E430D3A71D7318F210C9DE0CFB52E5AC8DE" },
   { name = "gleam_json", version = "0.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9A805C1E60FB9CD73AF3034EB464268A6B522D937FCD2DF92BD246F2F4B37930" },
   { name = "gleam_stdlib", version = "0.29.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "24581B17879AA903B3E7531869D9460730C2F772A1C02C774ABF75710CCC4CFE" },
-  { name = "hug", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_ansi"], otp_app = "hug", source = "hex", outer_checksum = "328A6FDE69A6CD57D2670EABBB44BB2EBA8E7D858694C24DB7A4450998EA30CD" },
+  { name = "hug", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_stdlib"], otp_app = "hug", source = "hex", outer_checksum = "328A6FDE69A6CD57D2670EABBB44BB2EBA8E7D858694C24DB7A4450998EA30CD" },
   { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
 ]
 
 [requirements]
 gleam_community_ansi = "~> 1.1"
+gleam_javascript = "~> 0.4"
 gleam_json = "~> 0.5"
 gleam_stdlib = "~> 0.29"
 hug = "~> 0.1"

--- a/src/bella.gleam
+++ b/src/bella.gleam
@@ -91,7 +91,9 @@ fn print_usage() {
     let distance = min_distance - string.length(current_cmd) + 3
     let cmd_desc =
       result.unwrap(list.at(result.unwrap(list.at(usage, i), [""]), 1), "")
-    io.println(current_cmd <> duplicate_string(" ", distance) <> cmd_desc)
+    io.println(
+      "bella " <> current_cmd <> duplicate_string(" ", distance) <> cmd_desc,
+    )
   })
   |> iterator.run()
   Nil


### PR DESCRIPTION
Reason: grids are cool.
Problem with the old way: it's not a grid, and grids are cool.

But really, this automatically adds spaces, meaning if new longer commands are added then all other lines don't need to be re-formatted manually(this would get especially tedious the more commands added).